### PR TITLE
Load dotenv & Add timeout to client.with

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.yardoc
 Gemfile.lock
 .rspec_status
+.env

--- a/lib/xfers/etcd/client.rb
+++ b/lib/xfers/etcd/client.rb
@@ -148,12 +148,14 @@ module Xfers
       # @param key [String] key name
       # @param value [String] the value of key
       # @param ttl [Integer] the advisory time-to-live in seconds, defaults to live forever
+      # @param lease [Integer] lease attached to the key, if ttl and lease are both provided, it will use ttl
       #
       # @return [void]
-      def put(key, value, ttl: nil)
+      def put(key, value, ttl: nil, lease: nil)
         synchronize do |client|
           self.class.valid_string_argument?("key", key)
           options = {}
+          options[:lease] = lease unless lease.nil?
           options[:lease] = self.lease_grant(ttl) if ttl&.respond_to?(:to_i)
           client.put(key, value.to_s, options)
           nil

--- a/lib/xfers/etcd/pool.rb
+++ b/lib/xfers/etcd/pool.rb
@@ -10,8 +10,8 @@ module Xfers
         end
       end
 
-      def with(&block)
-        @pool.with(&block)
+      def with(timeout: nil, &block)
+        @pool.with(timeout: timeout, &block)
       end
 
       def pool_shutdown(&block)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,11 +1,15 @@
 require "spec_helper"
 
 describe Xfers::Etcd::Client do # rubocop:disable RSpec/FilePath
+  let(:endpoints) do
+    ENV["ETCD_ENDPOINTS"] || "http://127.0.0.1:2379"
+  end
+
   let(:conn) do
-    described_class.new(endpoints: "http://127.0.0.1:2379", allow_reconnect: true)
+    described_class.new(endpoints: endpoints, allow_reconnect: true)
   end
   let(:conn2) do
-    described_class.new(endpoints: "http://127.0.0.1:2379", allow_reconnect: true)
+    described_class.new(endpoints: endpoints, allow_reconnect: true)
   end
 
   before do

--- a/spec/pool_spec.rb
+++ b/spec/pool_spec.rb
@@ -1,11 +1,15 @@
 require "spec_helper"
 
 describe Xfers::Etcd::Pool do # rubocop:disable RSpec/FilePath
+  let(:endpoints) do
+    ENV["ETCD_ENDPOINTS"] || "http://127.0.0.1:2379"
+  end
+
   let(:pool) do
     described_class.new(
       pool_size: 8,
       pool_timeout: 2,
-      endpoints: "http://127.0.0.1:2379",
+      endpoints: endpoints,
       allow_reconnect: true
     )
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,7 @@
 require "xfers-etcd-client"
+require "dotenv"
+
+Dotenv.load
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/xfers-etcd-client.gemspec
+++ b/xfers-etcd-client.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "redis", "~> 4.4"
   s.add_development_dependency "redlock", "~> 1.2"
   s.add_development_dependency "rspec", "~> 3.7"
+  s.add_development_dependency "dotenv", "~> 2.7"
 end


### PR DESCRIPTION
I am not able to access etcd in my computer.
Allow specifying `ETCD_ENDPOINTS` in `.env` during rspec